### PR TITLE
Clarify installation of mysqlnd on PHP 7

### DIFF
--- a/content/quickstart.md
+++ b/content/quickstart.md
@@ -20,12 +20,19 @@ data.
 on it, preferably with separate user credentials only for the DNS 
 stuff.
 
-3. Make sure that you have the *php5-mysqlnd* package installed and enabled:
-```
-sudo apt-get install php5-mysqlnd
-sudo php5enmod mysqlnd
-sudo service apache2 restart
-```
+3. Make sure that you have MySQL native driver installed and enabled:
+  * PHP 5.X: 
+  ```
+  sudo apt-get install php5-mysqlnd
+  sudo php5enmod mysqlnd
+  sudo service apache2 restart
+  ```
+  * PHP 7:
+  ```
+  sudo apt-get install php7.0-mysql
+  phpenmod -v 7.0 -s ALL mysql # should be auto enabled by above
+  sudo service apache2 restart
+  ```
 
 ### Install PDNS Manager
 


### PR DESCRIPTION
In PHP 7 - MySQL native driver is now included in php7.0-mysql package instead of php5-mysqlnd. Also there is now universal phpenmod command instead of php5enmod
